### PR TITLE
Fix SES send failures from malformed forwarded headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const { S3Client, CopyObjectCommand, GetObjectCommand } = require("@aws-sdk/client-s3");
 const { SESv2Client, SendEmailCommand } = require("@aws-sdk/client-sesv2");
 
-console.log("AWS Lambda SES Forwarder // @arithmetric // Version 5.1.0");
+console.log("AWS Lambda SES Forwarder // @arithmetric // Version 6.0.0");
 
 // Configure the S3 bucket and key prefix for stored raw emails, and the
 // mapping of email addresses to forward from and to.
@@ -42,7 +42,8 @@ var defaultConfig = {
   emailBucket: process.env.EMAIL_BUCKET || "",
   emailKeyPrefix: process.env.EMAIL_KEY_PREFIX || "",
   allowPlusSign: process.env.ALLOW_PLUS_SIGN || true,
-  forwardMapping: JSON.parse(process.env.FORWARD_MAPPING) || ""
+  forwardMapping: process.env.FORWARD_MAPPING ?
+    JSON.parse(process.env.FORWARD_MAPPING) : {}
 };
 
 /**
@@ -202,6 +203,12 @@ exports.processMessage = function(data) {
   var header = match && match[1] ? match[1] : data.emailData;
   var body = match && match[2] ? match[2] : '';
 
+  // Remove any Reply-To header with an empty address (e.g. `Reply-To: "N" <>`),
+  // which SES rejects with "BadRequestException: Empty address". Stripping it
+  // here lets the logic below regenerate a valid Reply-To from the From address.
+  header = header.replace(
+    /^reply-to:[\t ]?.*<\s*>.*\r?\n(\s+.*\r?\n)*/mgi, '');
+
   // Add "Reply-To:" with the "From" address if it doesn't already exists
   if (!/^reply-to:[\t ]?/mi.test(header)) {
     match = header.match(/^from:[\t ]?(.*(?:\r?\n\s+.*)*\r?\n)/mi);
@@ -253,13 +260,13 @@ exports.processMessage = function(data) {
   }
 
   // Remove the Return-Path header.
-  header = header.replace(/^return-path:[\t ]?(.*)\r?\n/mgi, '');
+  header = header.replace(/^return-path:[\t ]?.*\r?\n(\s+.*\r?\n)*/mgi, '');
 
   // Remove Sender header.
-  header = header.replace(/^sender:[\t ]?(.*)\r?\n/mgi, '');
+  header = header.replace(/^sender:[\t ]?.*\r?\n(\s+.*\r?\n)*/mgi, '');
 
   // Remove Message-ID header.
-  header = header.replace(/^message-id:[\t ]?(.*)\r?\n/mgi, '');
+  header = header.replace(/^message-id:[\t ]?.*\r?\n(\s+.*\r?\n)*/mgi, '');
 
   // Remove all DKIM-Signature headers to prevent triggering an
   // "InvalidParameterValue: Duplicate header 'DKIM-Signature'" error.

--- a/test/processMessage.js
+++ b/test/processMessage.js
@@ -174,5 +174,85 @@ describe('index.js', function() {
           done();
         });
     });
+
+    // Regression: some mail servers fold the Message-ID value onto a
+    // continuation line. A removal regex that only matched a single line left
+    // the folded continuation behind, where it attached to the preceding
+    // Content-Type header and corrupted its boundary parameter. SES then
+    // rejected the send with "BadRequestException: In parameter list ...
+    // expected ';', got '<'".
+    it('should remove a folded (multiline) Message-ID header', function(done) {
+      var data = {
+        config: {},
+        email: { source: "betsy@example.com" },
+        emailData: [
+          "Received: from example.com (example.com [127.0.0.1])",
+          " by inbound-smtp.us-west-2.amazonaws.com with SMTP id abc123",
+          " for info@example.com;",
+          " Fri, 11 Mar 2016 06:20:55 +0000 (UTC)",
+          "From: Betsy <betsy@example.com>",
+          "To: info@example.com",
+          "Subject: Folded headers test",
+          "Content-Type: multipart/alternative;",
+          " boundary=\"--boundary_0001\"",
+          "Message-ID:",
+          " <folded-message-id@example.com>",
+          "Date: Fri, 11 Mar 2016 01:20:54 -0500",
+          "",
+          "This is a test message to info@example.com.",
+          ""
+        ].join("\r\n"),
+        log: console.log,
+        recipients: ["jim@example.com"],
+        originalRecipient: "info@example.com"
+      };
+      index.processMessage(data)
+        .then(function(data) {
+          assert.ok(!/folded-message-id/.test(data.emailData),
+            "folded Message-ID should be removed entirely");
+          assert.ok(/boundary="--boundary_0001"/.test(data.emailData),
+            "Content-Type boundary parameter should be preserved");
+          assert.ok(!/boundary="[^"]*"\r?\n\s*</.test(data.emailData),
+            "boundary must not be followed by an orphaned <message-id>");
+          done();
+        });
+    });
+
+    // Regression: some senders emit an empty Reply-To address (e.g.
+    // `Reply-To: "N" <>`). Forwarding it verbatim made SES reject the send
+    // with "BadRequestException: Empty address". The empty header should be
+    // dropped and a valid Reply-To regenerated from the From address.
+    it('should replace an empty Reply-To address', function(done) {
+      var data = {
+        config: {},
+        email: { source: "betsy@example.com" },
+        emailData: [
+          "Received: from example.com (example.com [127.0.0.1])",
+          " for info@example.com;",
+          " Fri, 11 Mar 2016 06:20:55 +0000 (UTC)",
+          "Reply-To: \"N\" <>",
+          "From: betsy@example.com",
+          "To: info@example.com",
+          "Subject: Empty Reply-To test",
+          "Date: Fri, 11 Mar 2016 01:20:54 -0500",
+          "",
+          "Body here.",
+          ""
+        ].join("\r\n"),
+        log: console.log,
+        recipients: ["jim@example.com"],
+        originalRecipient: "info@example.com"
+      };
+      index.processMessage(data)
+        .then(function(data) {
+          assert.ok(!/<\s*>/.test(data.emailData),
+            "empty <> address should be removed");
+          assert.ok(!/"N"/.test(data.emailData),
+            "the empty Reply-To header should be dropped");
+          assert.ok(/Reply-To: betsy@example\.com/.test(data.emailData),
+            "a valid Reply-To should be derived from the From address");
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
Several inbound messages caused SendEmailCommand to fail because processMessage left address/MIME headers in an invalid state:

- Folded (multiline) Message-ID, Return-Path, and Sender headers were only stripped on their first line, leaving the continuation line orphaned. It then attached to the preceding Content-Type header and corrupted its boundary parameter, triggering "BadRequestException: In parameter list ... expected ';', got '<'". These removals now consume folded continuation lines, matching the existing DKIM-Signature handling.

- An empty Reply-To address (e.g. `Reply-To: "N" <>`) was forwarded verbatim, causing "BadRequestException: Empty address". Empty Reply-To headers are now stripped so a valid one is regenerated from the From address.

Also harden defaultConfig so a missing FORWARD_MAPPING env var no longer throws at module load (JSON.parse(undefined)), which broke both cold starts and the test/CI run, and sync the startup banner to 6.0.0.

Adds regression tests for the folded Message-ID and empty Reply-To cases.