### PR TITLE
Fix SES send failure from invalid From address in Reply-To

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,11 @@ exports.processMessage = function(data) {
   if (!/^reply-to:[\t ]?/mi.test(header)) {
     match = header.match(/^from:[\t ]?(.*(?:\r?\n\s+.*)*\r?\n)/mi);
     var from = match && match[1] ? match[1] : '';
-    if (from) {
+    // Only regenerate a Reply-To when the From address is a syntactically
+    // valid address.
+    var addrMatch = from.match(/<([^>]*)>/);
+    var address = (addrMatch ? addrMatch[1] : from).trim();
+    if (from && /^[^\s@]+@[^\s@]+$/.test(address)) {
       header = header + 'Reply-To: ' + from;
       data.log({
         level: "info",

--- a/test/processMessage.js
+++ b/test/processMessage.js
@@ -254,5 +254,40 @@ describe('index.js', function() {
           done();
         });
     });
+
+    // Regression: some senders emit a malformed From where the angle brackets
+    // hold a display name rather than an address (e.g.
+    // `Some Sender <Some Sender>`). Forwarding it into a regenerated Reply-To
+    // made SES reject the send with "BadRequestException: Local address
+    // contains control or whitespace". No Reply-To should be added when the
+    // From address is not valid.
+    it('should not add a Reply-To when the From address is invalid',
+      function(done) {
+        var data = {
+          config: {},
+          email: { source: "betsy@example.com" },
+          emailData: [
+            "Received: from example.com (example.com [127.0.0.1])",
+            " for info@example.com;",
+            " Fri, 11 Mar 2016 06:20:55 +0000 (UTC)",
+            "From: Some Sender <Some Sender>",
+            "To: info@example.com",
+            "Subject: Invalid From test",
+            "Date: Fri, 11 Mar 2016 01:20:54 -0500",
+            "",
+            "Body here.",
+            ""
+          ].join("\r\n"),
+          log: console.log,
+          recipients: ["jim@example.com"],
+          originalRecipient: "info@example.com"
+        };
+        index.processMessage(data)
+          .then(function(data) {
+            assert.ok(!/^reply-to:/mi.test(data.emailData),
+              "no Reply-To should be added for an invalid From address");
+            done();
+          });
+      });
   });
 });


### PR DESCRIPTION
## Context

The Lambda failed to forward an inbound email, with SES rejecting the send three times:

> `BadRequestException: Local address contains control or whitespace`

The message had a malformed `From:` header where the angle brackets held a display name instead of an email address (so the "address" contained whitespace). `processMessage` copied that value verbatim into a regenerated `Reply-To:`, and SES rejected the whole send. This is the same failure class as the earlier empty-`<>` fix (`d042632`), just a non-empty-but-invalid variant it didn't cover.

## Change

- `index.js`: before regenerating `Reply-To` from `From`, extract the address (inside `<>`, else the bare token) and only add the header when it matches `^[^\s@]+@[^\s@]+$`. Invalid From addresses fall through to the existing "Reply-To not added" branch. Valid senders are unaffected.
- `test/processMessage.js`: regression test asserting no `Reply-To` is emitted for an invalid From address.

## Verification

Full suite passes: **30 passing, 100% statement/line/function coverage.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)